### PR TITLE
Command specific handlers

### DIFF
--- a/cmds/ping.js
+++ b/cmds/ping.js
@@ -1,7 +1,8 @@
 module.exports = {
     name: "ping",
-    execute(client, Discord, message, args) {
-    const r = new Discord.MessageEmbed()
+    execute(message, client) {
+        const Discord = require('discord.js');
+        const r = new Discord.MessageEmbed()
             .setColor('#ffb347')
             .setTitle(`  ☃️   Ping   ☃️  `)
             .setDescription(`Latency is ${Date.now() - message.createdTimestamp}ms and the API Latency is ${Math.round(client.ws.ping)}ms`)

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "token": "tokenCode",
+    "token": "token",
     "prefix": "?"
 }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ client.on('message', message => {
     if (!client.commands.has(command)) return;
 
     try {
-        client.commands.get(command).execute(client, Discord, message, args);
+        client.commands.get(command).execute(message, client);
     } catch (error) {
         console.error(error);
         const r = new Discord.MessageEmbed()


### PR DESCRIPTION
Instead of passing `client, Discord, message, args` you could pass command specific arguments. 
So for ping.js it wouldn't need Discord or args, just message and client
